### PR TITLE
add hexagon shape and border color

### DIFF
--- a/kohonen/R/plot.kohonen.R
+++ b/kohonen/R/plot.kohonen.R
@@ -36,8 +36,11 @@ Hexagon <- function (a, b, unitcell = 1, col = "grey", border=NA) {
 }
 
 hexagons <- function(x, y, unitcell, col, border) {
+    # col can be a vector of values coming from the palette,
+    # or simply one value ('black'): then replicate that color
     if (length(col) != length(x))
         col <- rep(col[1], length(x))
+
     for (idx in 1:length(x))
         Hexagon(x[idx], y[idx],
                 unitcell = unitcell, col = col[idx], border = border)
@@ -54,7 +57,7 @@ hexagons <- function(x, y, unitcell, col, border) {
                             bgcol=NULL, zlim = NULL, heatkey = TRUE,
                             property, contin, whatmap = NULL,
                             codeRendering = NULL, keepMargins = FALSE,
-                            heatkeywidth = .2, shape = c("circle", "hexagon"),
+                            heatkeywidth = .2, shape = c("round", "straight"),
                             border = "black", ...)
 {
   type <- match.arg(type)
@@ -114,7 +117,7 @@ plot.somgrid <- function(x, xlim, ylim, ...)
 ### Adapted for version 2.0: April 11.
 
 plot.kohmapping <- function(x, classif, main, labels, pchs, bgcol,
-                            keepMargins, shape = c("circle", "hexagon"),
+                            keepMargins, shape = c("round", "straight"),
                             border = "black", ...)
 {
   if (is.null(main)) main <- "Mapping plot"
@@ -149,13 +152,22 @@ plot.kohmapping <- function(x, classif, main, labels, pchs, bgcol,
 
   if (is.null(bgcol)) bgcol <- "transparent"
 
+  # choose symbol to draw based on shape (round, square), and grid (rect, hex)
   shape <- match.arg(shape)
-  switch(shape,
+  sym <- ifelse(shape == 'round', 'circle',
+                ifelse(x$grid$topo == 'rectangular', 'square', 'hexagon'))
+
+  switch(sym,
          circle = symbols(x$grid$pts[, 1], x$grid$pts[, 2],
                           circles = rep(0.5, nrow(x$grid$pts)),
-                          inches = FALSE, add = TRUE, bg = bgcol),
+                          inches = FALSE, add = TRUE,
+                          fg = border, bg = bgcol),
          hexagon = hexagons(x$grid$pts[, 1], x$grid$pts[, 2],
-                            unitcell = 1, col = bgcol, border = border)
+                            unitcell = 1, col = bgcol, border = border),
+         square = symbols(x$grid$pts[, 1], x$grid$pts[, 2],
+                          squares = rep(1, nrow(x$grid$pts)),
+                          inches = FALSE, add = TRUE,
+                          fg = border, bg = bgcol)
          )
 
   if (is.null(labels) & !is.null(pchs))
@@ -176,7 +188,7 @@ plot.kohmapping <- function(x, classif, main, labels, pchs, bgcol,
 
 plot.kohprop <- function(x, property, main, palette.name, ncolors,
                          zlim, heatkey, contin, keepMargins,
-                         heatkeywidth, shape = c("circle", "hexagon"),
+                         heatkeywidth, shape = c("round", "straight"),
                          border = "black", ...)
 {
   if (is.null(main)) main <- "Property plot"
@@ -216,13 +228,22 @@ plot.kohprop <- function(x, property, main, palette.name, ncolors,
                                include.lowest = TRUE))
   bgcolors[!is.na(showcolors)] <- bgcol[showcolors[!is.na(showcolors)]]
 
+  # choose symbol to draw based on shape (round, square), and grid (rect, hex)
   shape <- match.arg(shape)
-  switch(shape,
+  sym <- ifelse(shape == 'round', 'circle',
+                ifelse(x$grid$topo == 'rectangular', 'square', 'hexagon'))
+
+  switch(sym,
          circle = symbols(x$grid$pts[, 1], x$grid$pts[, 2],
-                          circles = rep(0.5, nrow(x$grid$pts)),
-                          inches = FALSE, add = TRUE, bg = bgcolors),
+                         circles = rep(0.5, nrow(x$grid$pts)),
+                         inches = FALSE, add = TRUE,
+                         fg = border, bg = bgcolors),
          hexagon = hexagons(x$grid$pts[, 1], x$grid$pts[, 2],
-                            unitcell = 1, col = bgcolors, border = border)
+                            unitcell = 1, col = bgcolors, border = border),
+         square = symbols(x$grid$pts[, 1], x$grid$pts[, 2],
+                          squares = rep(1, nrow(x$grid$pts)),
+                          inches = FALSE, add = TRUE,
+                          fg = border, bg = bgcolors)
          )
 
   ## if contin, a pretty labelling of z colors will be used; if not,
@@ -429,7 +450,7 @@ plot.kohquality <- function(x, classif, main, palette.name, ncolors,
 ### Added palette.name for version 2.0.6. Aug 3, 2010.
 
 plot.kohcodes <- function(x, main, palette.name, bgcol, whatmap,
-                          codeRendering, keepMargins, shape = c("circle", "hexagon"),
+                          codeRendering, keepMargins, shape = c("round", "straight"),
                           border = "black", ...)
 {
   if (!keepMargins) {
@@ -559,13 +580,22 @@ plot.kohcodes <- function(x, main, palette.name, bgcol, whatmap,
 
     if (is.null(bgcol)) bgcol <- "transparent"
 
+    # choose symbol to draw based on shape (round, square), and grid (rect, hex)
     shape <- match.arg(shape)
-    switch(shape,
+    sym <- ifelse(shape == 'round', 'circle',
+                  ifelse(x$grid$topo == 'rectangular', 'square', 'hexagon'))
+
+    switch(sym,
            circle = symbols(x$grid$pts[, 1], x$grid$pts[, 2],
                             circles = rep(0.5, nrow(x$grid$pts)),
-                            inches = FALSE, add = TRUE, bg = bgcol),
+                            inches = FALSE, add = TRUE,
+                            fg = border, bg = bgcol),
            hexagon = hexagons(x$grid$pts[, 1], x$grid$pts[, 2],
-                              unitcell = 1, col = bgcol, border = border)
+                              unitcell = 1, col = bgcol, border = border),
+           square = symbols(x$grid$pts[, 1], x$grid$pts[, 2],
+                            squares = rep(1, nrow(x$grid$pts)),
+                            inches = FALSE, add = TRUE,
+                            fg = border, bg = bgcol)
            )
 
     if (codeRendering == "lines") {

--- a/kohonen/man/plot.kohonen.Rd
+++ b/kohonen/man/plot.kohonen.Rd
@@ -14,7 +14,7 @@
      palette.name = NULL, ncolors, bgcol = NULL,
      zlim = NULL, heatkey = TRUE, property, contin,
      whatmap = NULL, codeRendering = NULL, keepMargins = FALSE,
-     heatkeywidth = .2, shape = c("circle", "hexagon"),
+     heatkeywidth = .2, shape = c("round", "straight"),
      border = "black", \dots)
 \method{identify}{kohonen}(x, \dots)
 add.cluster.boundaries(x, clustering, lwd = 5, ...)
@@ -60,8 +60,10 @@ add.cluster.boundaries(x, clustering, lwd = 5, ...)
   \item{heatkeywidth}{width of the colour key; the default of 0.2 should
     work in most cases but in some cases, e.g. when plotting multiple
     figures, it may need to be adjusted.}
-  \item{shape}{choose the shape to be drawn: 'circle' (default) or 'hexagon'}
-  \item{border}{color of the hexagon border: only useful when drawing hexagons}
+  \item{shape}{kind shape to be drawn: "round" (circle) or "straight".
+    Choosing "straight" produces a map of squares when the grid is "rectangular",
+    and produces a map of hexagons when the grid is "hexagonal".}
+  \item{border}{color of the shapes's border.}
   \item{lwd, \dots}{other graphical parameters.}
   \item{clustering}{cluster labels of the map units.}
 }

--- a/kohonen/man/plot.kohonen.Rd
+++ b/kohonen/man/plot.kohonen.Rd
@@ -14,7 +14,8 @@
      palette.name = NULL, ncolors, bgcol = NULL,
      zlim = NULL, heatkey = TRUE, property, contin,
      whatmap = NULL, codeRendering = NULL, keepMargins = FALSE,
-     heatkeywidth = .2, \dots)
+     heatkeywidth = .2, shape = c("circle", "hexagon"),
+     border = "black", \dots)
 \method{identify}{kohonen}(x, \dots)
 add.cluster.boundaries(x, clustering, lwd = 5, ...)
 }
@@ -59,13 +60,15 @@ add.cluster.boundaries(x, clustering, lwd = 5, ...)
   \item{heatkeywidth}{width of the colour key; the default of 0.2 should
     work in most cases but in some cases, e.g. when plotting multiple
     figures, it may need to be adjusted.}
+  \item{shape}{choose the shape to be drawn: 'circle' (default) or 'hexagon'}
+  \item{border}{color of the hexagon border: only useful when drawing hexagons}
   \item{lwd, \dots}{other graphical parameters.}
   \item{clustering}{cluster labels of the map units.}
 }
 \details{Several different types of plots are supported:
   \describe{
     \item{"changes"}{shows the mean distance to the closest codebook vector
-      during training.} 
+      during training.}
     \item{"codes"}{shows the codebook vectors.}
     \item{"counts"}{shows the number of objects mapped to the
       individual units. Empty units are depicted in gray.}
@@ -92,7 +95,7 @@ add.cluster.boundaries(x, clustering, lwd = 5, ...)
   clicked on with the mouse. The tolerance is calculated from the ratio
   of the plotting region and the user coordinates, so clicking at any
   place within a unit should work.
-  
+
   Function \code{add.cluster.boundaries} will add to an existing plot of
   a map thick lines, visualizing which units would be clustered
   together. In toroidal maps, boundaries at the edges will only be shown
@@ -117,7 +120,7 @@ coolBlueHotRed <- function(n, alpha = 1) {
   rainbow(n, end=4/6, alpha=alpha)[n:1]
 }
 plot(kohmap, type="quality", palette.name = coolBlueHotRed)
-plot(kohmap, type="mapping", 
+plot(kohmap, type="mapping",
      labels = wine.classes, col = wine.classes+1,
      main = "mapping plot")
 
@@ -125,7 +128,7 @@ plot(kohmap, type="mapping",
 xyfpredictions <- classmat2classvec(predict(kohmap)$unit.predictions)
 bgcols <- c("gray", "pink", "lightgreen")
 plot(kohmap, type="mapping", col = wine.classes+1,
-     pchs = wine.classes, bgcol = bgcols[as.integer(xyfpredictions)], 
+     pchs = wine.classes, bgcol = bgcols[as.integer(xyfpredictions)],
      main = "another mapping plot")
 
 ## Show 'component planes'


### PR DESCRIPTION
Hi,

Thank you for this package! 

This contribution allows one to draw hexagons instead of circles, and to set their border color:

- add `shape = 'hexagon'` to any plot command that usually produces circles.
- add `shape = 'hexagon', border = 'blue'` in order to produce blue-bordered hexagons

Your tutorial at http://www.inside-r.org/packages/cran/kohonen/docs/add.cluster.boundaries
completely works with this functionality.

For instance,

    data(wines)
    set.seed(7)
 
    kohmap <- xyf(scale(wines), classvec2classmat(wine.classes),
                            grid = somgrid(5, 5, "hexagonal"), rlen=100)
    plot(kohmap, type="changes")
    plot(kohmap, type="codes", main = c("Codes X", "Codes Y"), shape = 'hexagon')
    plot(kohmap, type="counts", shape = 'hexagon', border = 'pink')

# Motivation
I was inspired by a Stackoverflow [thread](http://stackoverflow.com/questions/19858729/r-package-kohonen-how-to-plot-hexagons-instead-of-circles-as-in-matlab-som-too), but I did not understand why they made their hexagon shapes too tall: the shapes overlap each other. Also, I think being able to natively plot hexagons is cool, there is no need for additional package. So, overall, I think this makes a nice addition to the package.

I have noticed a longer time to draw in 'hexagon' mode: I *think* this is because `symbols` is really faster than polygon. Anyway, the result is worth it when one needs hexagons.

Please tell me what your opinion is.

Best regards